### PR TITLE
fix: Enable class-based dark mode for Tailwind v4

### DIFF
--- a/core/app/routes/pricing.mdx
+++ b/core/app/routes/pricing.mdx
@@ -57,7 +57,7 @@ DevCle offers flexible pricing options from free open-source to enterprise solut
     </li>
   </ul>
 
-  <a href="https://github.com/goofmint/DevCle-app" target="_blank" rel="noopener noreferrer" className="block w-full text-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-200 transition-colors">
+  <a href="https://github.com/goofmint/DevCle-app" target="_blank" rel="noopener noreferrer" className="not-prose block w-full text-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:!text-gray-200 transition-colors">
     Get Started
   </a>
 </div>
@@ -99,7 +99,7 @@ DevCle offers flexible pricing options from free open-source to enterprise solut
     </li>
   </ul>
 
-  <a href="#" className="block w-full text-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+  <a href="#" className="not-prose block w-full text-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
     Start Free Trial
   </a>
 </div>
@@ -145,7 +145,7 @@ DevCle offers flexible pricing options from free open-source to enterprise solut
     </li>
   </ul>
 
-  <a href="#" className="block w-full text-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+  <a href="#" className="not-prose block w-full text-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
     Start Free Trial
   </a>
 </div>
@@ -187,7 +187,7 @@ DevCle offers flexible pricing options from free open-source to enterprise solut
     </li>
   </ul>
 
-  <a href="#" className="block w-full text-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-200 transition-colors">
+  <a href="#" className="not-prose block w-full text-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:!text-gray-200 transition-colors">
     Contact Sales
   </a>
 </div>
@@ -249,10 +249,10 @@ Choose a plan that fits your needs and start analyzing your DevRel activities to
   <h3 className="text-2xl font-bold mb-4 dark:text-gray-100">Start Your Free Trial Today</h3>
   <p className="text-gray-600 dark:text-gray-300 mb-6">No credit card required. 14-day free trial on Basic and Team plans.</p>
   <div className="flex gap-4 justify-center">
-    <a href="#" className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold">
+    <a href="#" className="not-prose px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold">
       Start Free Trial
     </a>
-    <a href="#" className="px-6 py-3 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-200 transition-colors font-semibold">
+    <a href="#" className="not-prose px-6 py-3 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:!text-gray-200 transition-colors font-semibold">
       Contact Sales
     </a>
   </div>

--- a/core/app/tailwind.css
+++ b/core/app/tailwind.css
@@ -8,6 +8,13 @@
 @plugin "@tailwindcss/typography";
 
 /**
+ * Dark mode configuration
+ * Enable class-based dark mode (e.g., <div class="dark">)
+ * Without this, dark mode defaults to prefers-color-scheme media query
+ */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/**
  * Custom base styles
  */
 @layer base {


### PR DESCRIPTION
Tailwind CSS v4ではクラスベースのダークモードを使用するために
@custom-variantディレクティブが必要。この設定がないと、dark:プレフィックスが
メディアクエリベース（prefers-color-scheme）としてのみ機能する。

Changes:
- Add @custom-variant dark to app/tailwind.css for class-based dark mode
- Add not-prose class to all buttons to prevent Typography plugin override
- Fix button text colors: text-gray-900 dark:!text-gray-200 for secondary buttons
- Remove if statements from E2E tests (make dark mode checks mandatory)
- Add comprehensive dark mode color verification tests

Test Results:
✅ All 18 E2E tests passing
✅ All 27 unit tests passing
✅ TypeScript checks passing
✅ Dark mode correctly applies gray-800 backgrounds and gray-200 text colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved dark mode implementation to use a class-based approach for consistent theming.
  - Refined link styling and text colors on the pricing page for better contrast, especially in dark mode.

- Tests
  - Expanded end-to-end coverage for dark mode on the pricing page, including presence and behavior of the theme toggle.
  - Added assertions for backgrounds, text, and button colors across plans and CTA sections, including mobile scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->